### PR TITLE
Fixed a typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A simple hugo theme for building educational material that could be presented as
 
 ## Usage
 
-Make sure to add the following to your `config.towl` file.
+Make sure to add the following to your `config.toml` file.
 
 ```toml
 theme = "slideout"


### PR DESCRIPTION
In the file `README.md`, you say the following:

> add the following to your `config.towl` file.

There is no file `config.towl`, this should be `config.toml`.

This PR aims to address this oversight, by replacing the incorrect file name (`config.towl`) with the correct one (`config.toml`) in the file `README.md`.


As an aside, the description of this repository also contains a typo, instead of

> Simple Hugo theme for makeing handout and slide all in ones. 

it should read

> Simple Hugo theme for making handout and slide all in ones.

(The difference being the removal of the extraneous `e` in "making".)